### PR TITLE
Rectified error in activity time trend y-axis label

### DIFF
--- a/Data-Explorer/server.R
+++ b/Data-Explorer/server.R
@@ -391,7 +391,7 @@ function(input, output, session)  {
         layout(
           showlegend = TRUE,
           yaxis = list(fixedrange = TRUE,
-                       title = input$measure_trend,
+                       title = input$measure_trend_2,
                        rangemode = "tozero"),
           
           # Axis parameter


### PR DESCRIPTION
Updated server.R file to rectify error in y-axis label for time trend (activity comparison).