### PR TITLE
HBres fix in data_preparation

### DIFF
--- a/Data-Explorer/data_preparation.R
+++ b/Data-Explorer/data_preparation.R
@@ -109,7 +109,7 @@ saveRDS(data_bed, paste0(
 # 3.1.1 - Residence data
 data_spec_ip_res <- read_csv(paste0(
   base_filepath,
-  "20190528_Inpatient_and_Daycase_Episodes_by_Health_Board_of_Residence_",
+  "20190528_Inpatient_and_Daycase_Stays_by_Health_Board_of_Residence_",
   "and_Specialty.csv")) %>%
   res()
 
@@ -180,7 +180,7 @@ rm(data_spec_ip_res, data_spec_ip_treat,
 # 4.1.1 - Residence data
 data_simd_ip_res <- read_csv(paste0(
   base_filepath,
-  "20190528_Inpatient_and_Daycase_Episodes_by_Health_Board_of_Residence_",
+  "20190528_Inpatient_and_Daycase_Stays_by_Health_Board_of_Residence_",
   "and_SIMD.csv")) %>%
   res()
 


### PR DESCRIPTION
The data preparation script was using stays for hb treatment and episodes for HB residences for inpatient specialty and SIMD. In addition to being inconsistent this also broke the visualisations and tables for the HB residence data in both. I've changed the script to use stays for the HB residence data.